### PR TITLE
Upgrade action to Node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,5 +65,5 @@ inputs:
     description: Custom signature to be used at the bottom of the comment
     required: false
 runs:
-  using: node12
+  using: node16
   main: bin/index.js


### PR DESCRIPTION
Solves the following GitHub warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: lucassabreu/comment-coverage-clover